### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 the_french_artist
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Ranked from best to worse:
 Contributions to the Maze Benchmark project are more than welcome! If you have suggestions for improving the code, new features, or bug fixes, please feel free to fork the repository and submit a pull request.
 
 ## License
-This project is licensed under the MIT License - see the LICENSE file in the repository for details.
+This project is licensed under the MIT License — see the [LICENSE](LICENSE) file in the repository for details.
 
 ## Learn More
 For more information about the Maze Benchmark project, visit our [GitHub repository](https://github.com/louispaulet/maze_benchmark).


### PR DESCRIPTION
## Summary
- add MIT `LICENSE`
- link to the license from the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849ea54b84c832085b6ac58141ad2e1